### PR TITLE
임시 테이블 전략을 사용하여 DB 병합 작업.

### DIFF
--- a/core-api/src/services/patients/infrastructure/patients.repository.ts
+++ b/core-api/src/services/patients/infrastructure/patients.repository.ts
@@ -35,6 +35,8 @@ export class PatientsRepository extends DddRepository<Patient> {
     await this.entityManager.transaction(async (transactionEntityManager) => {
       const queryRunner = transactionEntityManager.queryRunner!;
 
+      // NOTE: 임시 테이블 전략으로 데이터베이서 과부하를 줄이자. (절대 순서를 바꾸지 말것.)
+      // step 1. 임시 테이블 생성
       await queryRunner.query(`
         CREATE TEMPORARY TABLE temp_patient (
           chart VARCHAR(255),
@@ -46,6 +48,7 @@ export class PatientsRepository extends DddRepository<Patient> {
         )
       `);
 
+      // step 2. patients 모두 임시 테이블에 삽입
       await transactionEntityManager
         .createQueryBuilder()
         .insert()
@@ -53,43 +56,49 @@ export class PatientsRepository extends DddRepository<Patient> {
         .values(patients)
         .execute();
 
-      //       // step 3: chart 있는 데이터가 chart 없는 기존 레코드를 업데이트 (빈 값은 덮어쓰지 않음)
-      //       await queryRunner.query(`
-      //   UPDATE patient p
-      //   JOIN temp_patient_import t
-      //     ON p.chart = '' AND t.chart != ''
-      //     AND p.name = t.name AND p.phone = t.phone
-      //   SET
-      //     p.chart = t.chart,
-      //     p.name = COALESCE(NULLIF(t.name, ''), p.name),
-      //     p.address = COALESCE(NULLIF(t.address, ''), p.address),
-      //     p.memo = COALESCE(NULLIF(t.memo, ''), p.memo)
-      // `);
+      // step 3: chart, name, phone이 모두 동일한 레코드에 대하여 업데이트
+      await queryRunner.query(`
+        UPDATE patient p
+          JOIN temp_patient t
+            ON p.chart = t.chart AND p.name = t.name AND p.phone = t.phone
+        SET
+          p.rrn = COALESCE(NULLIF(t.rrn, ''), p.rrn),
+          p.address = COALESCE(NULLIF(t.address, ''), p.address),
+          p.memo = COALESCE(NULLIF(t.memo, ''), p.memo)
+      `);
 
-      //       // step 4: chart 없는 데이터가 chart 있는 기존 레코드를 업데이트 (chart는 덮어쓰지 않음)
-      //       await queryRunner.query(`
-      // -- step 4: chart 없는 데이터를 chart 있는 기존 레코드에 병합 (값이 있는 것만 덮어쓰기)
-      // UPDATE patient p
-      // JOIN temp_patient_import t
-      //   ON p.chart != '' AND t.chart = ''
-      //   AND p.name = t.name AND p.phone = t.phone
-      // SET
-      //   p.name = t.name,
-      //   p.address = IFNULL(NULLIF(t.address, ''), p.address),
-      //   p.memo = IFNULL(NULLIF(t.memo, ''), p.memo)
+      // step 4: chart 가 있는 데이터 -> chart가 없는 기존 레코드를 업데이트한다. (chart도 업데이트.)
+      await queryRunner.query(`
+        UPDATE patient p
+        JOIN temp_patient t
+        ON p.chart = '' AND t.chart != '' AND p.name = t.name AND p.phone = t.phone
+      SET
+        p.chart = t.chart,
+        p.rrn = COALESCE(NULLIF(t.rrn, ''), p.rrn),
+        p.address = COALESCE(NULLIF(t.address, ''), p.address),
+        p.memo = COALESCE(NULLIF(t.memo, ''), p.memo)
+      `);
 
-      // `);
+      // step 5: chart 가 없는 데이터 -> chart가 있는 기존 레코드를 업데이트한다. (chart는 예외.)
+      await queryRunner.query(`
+        UPDATE patient p
+        JOIN temp_patient t
+        ON p.chart = '' AND t.chart != '' AND p.name = t.name AND p.phone = t.phone
+      SET
+        p.rrn = COALESCE(NULLIF(t.rrn, ''), p.rrn),
+        p.address = COALESCE(NULLIF(t.address, ''), p.address),
+        p.memo = COALESCE(NULLIF(t.memo, ''), p.memo)
+      `);
 
-      //       // step 5: chart 없는 데이터 중 기존에 없던 환자 insert
-      //       await queryRunner.query(`
-      // INSERT INTO patient (chart, name, phone, rrn, address, memo)
-      // SELECT t.chart, t.name, t.phone, t.rrn, t.address, t.memo
-      // FROM temp_patient_import t
-      // LEFT JOIN patient p
-      //   ON t.name = p.name AND t.phone = p.phone
-      // WHERE p.id IS NULL
-
-      // `);
+      // step 5: chart 없는 데이터 중 기존에 없던 환자 insert
+      await queryRunner.query(`
+      INSERT INTO patient (chart, name, phone, rrn, address, memo)
+        SELECT t.chart, t.name, t.phone, t.rrn, t.address, t.memo
+        FROM temp_patient t
+          LEFT JOIN patient p
+          ON t.chart = p.chart AND t.name = p.name AND t.phone = p.phone
+        WHERE p.id IS NULL AND t.chart != ''
+      `);
 
       await queryRunner.query(`DROP TEMPORARY TABLE IF EXISTS temp_patient`);
     });


### PR DESCRIPTION
전략 1. 
식별키 (name, phone) 기반으로 select해와서 비교하고 다시 병합작업을 한다음에 데이터베이스에 저장하는 방법.
-> 복합 인덱스를 name, phone으로 설정해도
select ... where  in [김환자1, 010...] or [김환자2, ,010..] 처럼하면 어차피 인덱스 안탐. 풀스캔으로 돌아가니 소용이 없다.

전략2.

기존 테이블도 동일한 임시테이블을 생성하여 데이터베이스 내부적으로 join하여 성능 최적화.
-> where 조건이 직접 명시되는 것과 같으므로 인덱스 탈 것.
속도상으로 전략 1보다는 빠름.